### PR TITLE
refactor: refactor bad smell UnnecessaryToStringCall

### DIFF
--- a/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/SelectManyRendererBase.java
+++ b/tobago-core/src/main/java/org/apache/myfaces/tobago/internal/renderkit/renderer/SelectManyRendererBase.java
@@ -471,7 +471,7 @@ public abstract class SelectManyRendererBase<T extends AbstractUISelectManyBase>
     }
     intBuilder.append("]");
 
-    builder.insert(0, intBuilder.toString());
+    builder.insert(0, intBuilder);
 
     getPathToComponent(component.getParent(), builder);
   }

--- a/tobago-tool/tobago-tool-apt/src/main/java/org/apache/myfaces/tobago/apt/processor/AbstractGenerator.java
+++ b/tobago-tool/tobago-tool-apt/src/main/java/org/apache/myfaces/tobago/apt/processor/AbstractGenerator.java
@@ -106,7 +106,7 @@ public abstract class AbstractGenerator extends AbstractProcessor {
     processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR,
         "<" + getClass().getSimpleName() + "> " + e.getMessage() + "\n"
             + (e.getCause() != null ? e.getCause().getMessage() + "\n" : "")
-            + out.toString());
+            + out);
   }
 
   public List<TypeElement> getTypes() {


### PR DESCRIPTION
# Repairing Code Style Issues
<!-- laughing-train-refactor -->
## UnnecessaryToStringCall
The `toString()` method is not needed in cases the underlying method handles the conversion. Also calling toString() on a String is redundant. Removing them simplifies the code.
<!-- fingerprint:Qodana-myfaces-tobago-UnnecessaryToStringCall-9624035749eac8ab101e94436c35846fad625e13-sl:474-el:0-sc:34-ec:0-co:19601-cl:8 -->
<!-- fingerprint:Qodana-myfaces-tobago-UnnecessaryToStringCall-9624035749eac8ab101e94436c35846fad625e13-sl:109-el:0-sc:19-ec:0-co:3683-cl:8 -->
# Repairing Code Style Issues
* UnnecessaryToStringCall (2)
