### PR TITLE
refactor: refactor bad smell InnerClassMayBeStatic

### DIFF
--- a/tobago-example/tobago-example-demo/src/main/java/org/apache/myfaces/tobago/example/demo/ForEachController.java
+++ b/tobago-example/tobago-example-demo/src/main/java/org/apache/myfaces/tobago/example/demo/ForEachController.java
@@ -89,7 +89,7 @@ public class ForEachController implements Serializable {
     discharge = null;
   }
 
-  public class River implements Serializable {
+  public static class River implements Serializable {
     private String name;
     private int length;
     private int discharge;

--- a/tobago-example/tobago-example-demo/src/main/java/org/apache/myfaces/tobago/example/demo/SheetFilterController.java
+++ b/tobago-example/tobago-example-demo/src/main/java/org/apache/myfaces/tobago/example/demo/SheetFilterController.java
@@ -238,7 +238,7 @@ public class SheetFilterController implements Serializable {
     return result;
   }
 
-  private class DistanceRange {
+  private static class DistanceRange {
 
     private int min;
     private int max;

--- a/tobago-example/tobago-example-demo/src/main/java/org/apache/myfaces/tobago/example/demo/TestController.java
+++ b/tobago-example/tobago-example-demo/src/main/java/org/apache/myfaces/tobago/example/demo/TestController.java
@@ -127,7 +127,7 @@ public class TestController implements Serializable {
     return testJsFiles;
   }
 
-  public class TestPage {
+  public static class TestPage {
     private final String id;
     private final String base;
     private final String label;


### PR DESCRIPTION
# Repairing Code Style Issues
<!-- laughing-train-refactor -->
## InnerClassMayBeStatic
Inner classes that do not reference their enclosing instances can be made static.
This prevents a common cause of memory leaks and uses less memory per instance of the class.

<!-- fingerprint:Qodana-myfaces-tobago-InnerClassMayBeStatic-9624035749eac8ab101e94436c35846fad625e13-sl:241-el:0-sc:17-ec:0-co:7039-cl:13 -->
<!-- fingerprint:Qodana-myfaces-tobago-InnerClassMayBeStatic-9624035749eac8ab101e94436c35846fad625e13-sl:130-el:0-sc:16-ec:0-co:4722-cl:8 -->
<!-- fingerprint:Qodana-myfaces-tobago-InnerClassMayBeStatic-9624035749eac8ab101e94436c35846fad625e13-sl:92-el:0-sc:16-ec:0-co:2221-cl:5 -->
# Repairing Code Style Issues
* InnerClassMayBeStatic (3)
